### PR TITLE
WIP: vo_gpu: hwdec_vaegl: vulkan interop

### DIFF
--- a/video/out/opengl/hwdec_vaegl.c
+++ b/video/out/opengl/hwdec_vaegl.c
@@ -20,9 +20,6 @@
 #include <assert.h>
 #include <unistd.h>
 
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
-
 #include <va/va_drmcommon.h>
 
 #include <libavutil/common.h>
@@ -32,26 +29,13 @@
 #include "config.h"
 
 #include "video/out/gpu/hwdec.h"
+#include "video/out/placebo/ra_pl.h"
+#include "video/out/vulkan/common.h"
 #include "video/mp_image_pool.h"
 #include "video/vaapi.h"
 #include "common.h"
 #include "ra_gl.h"
 #include "libmpv/render_gl.h"
-
-#ifndef GL_OES_EGL_image
-typedef void* GLeglImageOES;
-#endif
-#ifndef EGL_KHR_image
-typedef void *EGLImageKHR;
-#endif
-
-#ifndef EGL_LINUX_DMA_BUF_EXT
-#define EGL_LINUX_DMA_BUF_EXT             0x3270
-#define EGL_LINUX_DRM_FOURCC_EXT          0x3271
-#define EGL_DMA_BUF_PLANE0_FD_EXT         0x3272
-#define EGL_DMA_BUF_PLANE0_OFFSET_EXT     0x3273
-#define EGL_DMA_BUF_PLANE0_PITCH_EXT      0x3274
-#endif
 
 #if HAVE_VAAPI_X11
 #include <va/va_x11.h>
@@ -123,23 +107,10 @@ struct priv_owner {
 };
 
 struct priv {
-    int num_planes;
+    struct mp_image layout;
     struct ra_tex *tex[4];
-    GLuint gl_textures[4];
-    EGLImageKHR images[4];
-    VAImage current_image;
-    bool buffer_acquired;
-#if VA_CHECK_VERSION(1, 1, 0)
-    bool esh_not_implemented;
+    struct pl_vulkan_mem *mem[4];
     VADRMPRIMESurfaceDescriptor desc;
-    bool surface_acquired;
-#endif
-
-    EGLImageKHR (EGLAPIENTRY *CreateImageKHR)(EGLDisplay, EGLContext,
-                                              EGLenum, EGLClientBuffer,
-                                              const EGLint *);
-    EGLBoolean (EGLAPIENTRY *DestroyImageKHR)(EGLDisplay, EGLImageKHR);
-    void (EGLAPIENTRY *EGLImageTargetTexture2DOES)(GLenum, GLeglImageOES);
 };
 
 static void determine_working_formats(struct ra_hwdec *hw);
@@ -156,19 +127,16 @@ static int init(struct ra_hwdec *hw)
 {
     struct priv_owner *p = hw->priv;
 
-    if (!ra_is_gl(hw->ra) || !eglGetCurrentContext())
+    if (ra_is_gl(hw->ra)) {
+        MP_VERBOSE(hw, "using VAAPI EGL interop\n");
         return -1;
+    }
+    if (ra_pl_get(hw->ra)) {
+        //const struct pl_gpu *gpu = ra_pl_get(hw->ra);
+        // TODO: Check for dma_buf extension
 
-    const char *exts = eglQueryString(eglGetCurrentDisplay(), EGL_EXTENSIONS);
-    if (!exts)
-        return -1;
-
-    GL *gl = ra_gl_get(hw->ra);
-    if (!strstr(exts, "EXT_image_dma_buf_import") ||
-        !strstr(exts, "EGL_KHR_image_base") ||
-        !strstr(gl->extensions, "GL_OES_EGL_image") ||
-        !(gl->mpgl_caps & MPGL_CAP_TEX_RG))
-        return -1;
+        MP_VERBOSE(hw, "using VAAPI Vulkan interop\n");
+    }
 
     p->display = create_native_va_display(hw->ra, hw->log);
     if (!p->display) {
@@ -190,8 +158,6 @@ static int init(struct ra_hwdec *hw)
         return -1;
     }
 
-    MP_VERBOSE(hw, "using VAAPI EGL interop\n");
-
     determine_working_formats(hw);
     if (!p->formats || !p->formats[0]) {
         return -1;
@@ -205,47 +171,21 @@ static int init(struct ra_hwdec *hw)
 
 static void mapper_unmap(struct ra_hwdec_mapper *mapper)
 {
-    struct priv_owner *p_owner = mapper->owner->priv;
-    VADisplay *display = p_owner->display;
     struct priv *p = mapper->priv;
-    VAStatus status;
 
+    const struct pl_gpu *gpu = ra_pl_get(mapper->ra);
     for (int n = 0; n < 4; n++) {
-        if (p->images[n])
-            p->DestroyImageKHR(eglGetCurrentDisplay(), p->images[n]);
-        p->images[n] = 0;
-    }
-
-#if VA_CHECK_VERSION(1, 1, 0)
-    if (p->surface_acquired) {
-        for (int n = 0; n < p->desc.num_objects; n++)
-            close(p->desc.objects[n].fd);
-        p->surface_acquired = false;
-    }
-#endif
-
-    if (p->buffer_acquired) {
-        status = vaReleaseBufferHandle(display, p->current_image.buf);
-        CHECK_VA_STATUS(mapper, "vaReleaseBufferHandle()");
-        p->buffer_acquired = false;
-    }
-    if (p->current_image.image_id != VA_INVALID_ID) {
-        status = vaDestroyImage(display, p->current_image.image_id);
-        CHECK_VA_STATUS(mapper, "vaDestroyImage()");
-        p->current_image.image_id = VA_INVALID_ID;
+        ra_tex_free(mapper->ra, &mapper->tex[n]);
+        if (p->mem[n]) {
+          pl_vulkan_mem_deref(gpu, p->mem[n]);
+          MP_TRACE(mapper, "Object freed from %p\n", p->mem[n]);
+        }
+        p->mem[n] = 0;
     }
 }
 
 static void mapper_uninit(struct ra_hwdec_mapper *mapper)
 {
-    struct priv *p = mapper->priv;
-    GL *gl = ra_gl_get(mapper->ra);
-
-    gl->DeleteTextures(4, p->gl_textures);
-    for (int n = 0; n < 4; n++) {
-        p->gl_textures[n] = 0;
-        ra_tex_free(mapper->ra, &p->tex[n]);
-    }
 }
 
 static bool check_fmt(struct ra_hwdec_mapper *mapper, int fmt)
@@ -262,61 +202,17 @@ static int mapper_init(struct ra_hwdec_mapper *mapper)
 {
     struct priv_owner *p_owner = mapper->owner->priv;
     struct priv *p = mapper->priv;
-    GL *gl = ra_gl_get(mapper->ra);
-
-    p->current_image.buf = p->current_image.image_id = VA_INVALID_ID;
-
-    // EGL_KHR_image_base
-    p->CreateImageKHR = (void *)eglGetProcAddress("eglCreateImageKHR");
-    p->DestroyImageKHR = (void *)eglGetProcAddress("eglDestroyImageKHR");
-    // GL_OES_EGL_image
-    p->EGLImageTargetTexture2DOES =
-        (void *)eglGetProcAddress("glEGLImageTargetTexture2DOES");
-
-    if (!p->CreateImageKHR || !p->DestroyImageKHR ||
-        !p->EGLImageTargetTexture2DOES)
-        return -1;
 
     mapper->dst_params = mapper->src_params;
     mapper->dst_params.imgfmt = mapper->src_params.hw_subfmt;
     mapper->dst_params.hw_subfmt = 0;
 
     struct ra_imgfmt_desc desc = {0};
-    struct mp_image layout = {0};
 
     if (!ra_get_imgfmt_desc(mapper->ra, mapper->dst_params.imgfmt, &desc))
         return -1;
 
-    p->num_planes = desc.num_planes;
-    mp_image_set_params(&layout, &mapper->dst_params);
-
-    gl->GenTextures(4, p->gl_textures);
-    for (int n = 0; n < desc.num_planes; n++) {
-        gl->BindTexture(GL_TEXTURE_2D, p->gl_textures[n]);
-        gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-        gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        gl->TexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        gl->BindTexture(GL_TEXTURE_2D, 0);
-
-        struct ra_tex_params params = {
-            .dimensions = 2,
-            .w = mp_image_plane_w(&layout, n),
-            .h = mp_image_plane_h(&layout, n),
-            .d = 1,
-            .format = desc.planes[n],
-            .render_src = true,
-            .src_linear = true,
-        };
-
-        if (params.format->ctype != RA_CTYPE_UNORM)
-            return -1;
-
-        p->tex[n] = ra_create_wrapped_tex(mapper->ra, &params,
-                                          p->gl_textures[n]);
-        if (!p->tex[n])
-            return -1;
-    }
+    mp_image_set_params(&p->layout, &mapper->dst_params);
 
     if (!p_owner->probing_formats && !check_fmt(mapper, mapper->dst_params.imgfmt))
     {
@@ -328,26 +224,12 @@ static int mapper_init(struct ra_hwdec_mapper *mapper)
     return 0;
 }
 
-#define ADD_ATTRIB(name, value)                         \
-    do {                                                \
-    assert(num_attribs + 3 < MP_ARRAY_SIZE(attribs));   \
-    attribs[num_attribs++] = (name);                    \
-    attribs[num_attribs++] = (value);                   \
-    attribs[num_attribs] = EGL_NONE;                    \
-    } while(0)
-
 static int mapper_map(struct ra_hwdec_mapper *mapper)
 {
     struct priv_owner *p_owner = mapper->owner->priv;
     struct priv *p = mapper->priv;
-    GL *gl = ra_gl_get(mapper->ra);
     VAStatus status;
-    VAImage *va_image = &p->current_image;
     VADisplay *display = p_owner->display;
-
-#if VA_CHECK_VERSION(1, 1, 0)
-    if (p->esh_not_implemented)
-        goto esh_failed;
 
     status = vaExportSurfaceHandle(display, va_surface_id(mapper->src),
                                    VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME_2,
@@ -355,125 +237,77 @@ static int mapper_map(struct ra_hwdec_mapper *mapper)
                                    VA_EXPORT_SURFACE_SEPARATE_LAYERS,
                                    &p->desc);
     if (!CHECK_VA_STATUS(mapper, "vaAcquireSurfaceHandle()")) {
-        if (status == VA_STATUS_ERROR_UNIMPLEMENTED)
-            p->esh_not_implemented = true;
-        goto esh_failed;
+        goto error;
     }
-    p->surface_acquired = true;
 
-    for (int n = 0; n < p->num_planes; n++) {
-        int attribs[20] = {EGL_NONE};
-        int num_attribs = 0;
-
-        ADD_ATTRIB(EGL_LINUX_DRM_FOURCC_EXT, p->desc.layers[n].drm_format);
-        ADD_ATTRIB(EGL_WIDTH,  p->tex[n]->params.w);
-        ADD_ATTRIB(EGL_HEIGHT, p->tex[n]->params.h);
-
-#define ADD_PLANE_ATTRIBS(plane) do { \
-            ADD_ATTRIB(EGL_DMA_BUF_PLANE ## plane ## _FD_EXT, \
-                       p->desc.objects[p->desc.layers[n].object_index[plane]].fd); \
-            ADD_ATTRIB(EGL_DMA_BUF_PLANE ## plane ## _OFFSET_EXT, \
-                       p->desc.layers[n].offset[plane]); \
-            ADD_ATTRIB(EGL_DMA_BUF_PLANE ## plane ## _PITCH_EXT, \
-                       p->desc.layers[n].pitch[plane]); \
-        } while (0)
-
-        ADD_PLANE_ATTRIBS(0);
-        if (p->desc.layers[n].num_planes > 1)
-            ADD_PLANE_ATTRIBS(1);
-        if (p->desc.layers[n].num_planes > 2)
-            ADD_PLANE_ATTRIBS(2);
-        if (p->desc.layers[n].num_planes > 3)
-            ADD_PLANE_ATTRIBS(3);
-
-        p->images[n] = p->CreateImageKHR(eglGetCurrentDisplay(),
-            EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, NULL, attribs);
-        if (!p->images[n])
-            goto esh_failed;
-
-        gl->BindTexture(GL_TEXTURE_2D, p->gl_textures[n]);
-        p->EGLImageTargetTexture2DOES(GL_TEXTURE_2D, p->images[n]);
-
-        mapper->tex[n] = p->tex[n];
+    struct ra_imgfmt_desc desc;
+    if (!ra_get_imgfmt_desc(mapper->ra, mapper->dst_params.imgfmt, &desc)) {
+        goto error;
     }
-    gl->BindTexture(GL_TEXTURE_2D, 0);
+
+    const struct pl_gpu *gpu = ra_pl_get(mapper->ra);
+    for (int i = 0; i < p->desc.num_objects; i++) {
+        union pl_handle handle = {
+            .fd = p->desc.objects[i].fd,
+        };
+        p->mem[i] = pl_vulkan_mem_import(gpu, PL_HANDLE_DMA_BUF,
+                                         handle, p->desc.objects[i].size);
+        if (!p->mem[i]) {
+            close(p->desc.objects[i].fd);
+            goto error;
+        }
+        MP_TRACE(mapper, "Object %d with fd %d imported as %p\n",
+                 i, p->desc.objects[i].fd, p->mem[i]);
+    }
+    for (int n = 0; n < p->desc.num_layers; n++) {
+        if (p->desc.layers[n].num_planes > 1) {
+            // Should never happen because we request separate layers
+            MP_ERR(mapper, "Multi-plane VA surfaces are not supported\n");
+            goto error;
+        }
+
+        const struct ra_format *format = desc.planes[n];
+
+        struct pl_tex_params tex_params = {
+            .w = mp_image_plane_w(&p->layout, n),
+            .h = mp_image_plane_h(&p->layout, n),
+            .d = 0,
+            .format = format->priv,
+            .host_writable = true,
+            .sampleable = true,
+            .sample_mode = format->linear_filter ? PL_TEX_SAMPLE_LINEAR
+                                                 : PL_TEX_SAMPLE_NEAREST,
+            .handle_type = PL_HANDLE_DMA_BUF,
+        };
+
+        struct pl_vulkan_mem *mem = p->mem[p->desc.layers[n].object_index[0]];
+        uint32_t offset = p->desc.layers[n].offset[0];
+        const struct pl_tex *pltex = pl_vulkan_tex_import(gpu, &tex_params,
+                                                          mem, offset);
+        if (!pltex) {
+            goto error;
+        }
+
+        struct ra_tex *ratex = talloc_ptrtype(NULL, ratex);
+        int ret = mppl_wrap_tex(mapper->ra, pltex, ratex);
+        if (!ret) {
+            pl_tex_destroy(gpu, &pltex);
+            talloc_free(ratex);
+            goto error;
+        }
+        mapper->tex[n] = ratex;
+
+        pl_vulkan_release(gpu, pltex, VK_IMAGE_LAYOUT_GENERAL,
+                          VK_ACCESS_TRANSFER_READ_BIT, NULL);
+    }
 
     if (p->desc.fourcc == VA_FOURCC_YV12)
         MPSWAP(struct ra_tex*, mapper->tex[1], mapper->tex[2]);
 
     return 0;
 
-esh_failed:
-    if (p->surface_acquired) {
-        for (int n = 0; n < p->desc.num_objects; n++)
-            close(p->desc.objects[n].fd);
-        p->surface_acquired = false;
-    }
-#endif
-
-    status = vaDeriveImage(display, va_surface_id(mapper->src), va_image);
-    if (!CHECK_VA_STATUS(mapper, "vaDeriveImage()"))
-        goto err;
-
-    VABufferInfo buffer_info = {.mem_type = VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME};
-    status = vaAcquireBufferHandle(display, va_image->buf, &buffer_info);
-    if (!CHECK_VA_STATUS(mapper, "vaAcquireBufferHandle()"))
-        goto err;
-    p->buffer_acquired = true;
-
-    int drm_fmts[8] = {
-        // 1 bytes per component, 1-4 components
-        MKTAG('R', '8', ' ', ' '),       // DRM_FORMAT_R8
-        MKTAG('G', 'R', '8', '8'),       // DRM_FORMAT_GR88
-        0,                               // untested (DRM_FORMAT_RGB888?)
-        0,                               // untested (DRM_FORMAT_RGBA8888?)
-        // 2 bytes per component, 1-4 components
-        MKTAG('R', '1', '6', ' '),       // proposed DRM_FORMAT_R16
-        MKTAG('G', 'R', '3', '2'),       // proposed DRM_FORMAT_GR32
-        0,                               // N/A
-        0,                               // N/A
-    };
-
-    for (int n = 0; n < p->num_planes; n++) {
-        int attribs[20] = {EGL_NONE};
-        int num_attribs = 0;
-
-        const struct ra_format *fmt = p->tex[n]->params.format;
-        int n_comp = fmt->num_components;
-        int comp_s = fmt->component_size[n] / 8;
-        if (n_comp < 1 || n_comp > 3 || comp_s < 1 || comp_s > 2)
-            goto err;
-        int drm_fmt = drm_fmts[n_comp - 1 + (comp_s - 1) * 4];
-        if (!drm_fmt)
-            goto err;
-
-        ADD_ATTRIB(EGL_LINUX_DRM_FOURCC_EXT, drm_fmt);
-        ADD_ATTRIB(EGL_WIDTH, p->tex[n]->params.w);
-        ADD_ATTRIB(EGL_HEIGHT, p->tex[n]->params.h);
-        ADD_ATTRIB(EGL_DMA_BUF_PLANE0_FD_EXT, buffer_info.handle);
-        ADD_ATTRIB(EGL_DMA_BUF_PLANE0_OFFSET_EXT, va_image->offsets[n]);
-        ADD_ATTRIB(EGL_DMA_BUF_PLANE0_PITCH_EXT, va_image->pitches[n]);
-
-        p->images[n] = p->CreateImageKHR(eglGetCurrentDisplay(),
-            EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, NULL, attribs);
-        if (!p->images[n])
-            goto err;
-
-        gl->BindTexture(GL_TEXTURE_2D, p->gl_textures[n]);
-        p->EGLImageTargetTexture2DOES(GL_TEXTURE_2D, p->images[n]);
-
-        mapper->tex[n] = p->tex[n];
-    }
-    gl->BindTexture(GL_TEXTURE_2D, 0);
-
-    if (va_image->format.fourcc == VA_FOURCC_YV12)
-        MPSWAP(struct ra_tex*, mapper->tex[1], mapper->tex[2]);
-
-    return 0;
-
-err:
-    if (!p_owner->probing_formats)
-        MP_FATAL(mapper, "mapping VAAPI EGL image failed\n");
+error:
+    mapper_unmap(mapper);
     return -1;
 }
 

--- a/video/out/placebo/ra_pl.c
+++ b/video/out/placebo/ra_pl.c
@@ -8,13 +8,18 @@ struct ra_pl {
     const struct pl_gpu *gpu;
 };
 
-static inline const struct pl_gpu *get_gpu(struct ra *ra)
+static inline const struct pl_gpu *get_gpu(const struct ra *ra)
 {
     struct ra_pl *p = ra->priv;
     return p->gpu;
 }
 
 static struct ra_fns ra_fns_pl;
+
+const struct pl_gpu *ra_pl_get(const struct ra *ra)
+{
+    return ra->fns == &ra_fns_pl ? get_gpu(ra) : NULL;
+}
 
 struct ra *ra_create_pl(const struct pl_gpu *gpu, struct mp_log *log)
 {

--- a/video/out/placebo/ra_pl.h
+++ b/video/out/placebo/ra_pl.h
@@ -5,6 +5,8 @@
 
 struct ra *ra_create_pl(const struct pl_gpu *gpu, struct mp_log *log);
 
+const struct pl_gpu *ra_pl_get(const struct ra *ra);
+
 // Wrap a pl_tex into a ra_tex struct, returns if successful
 bool mppl_wrap_tex(struct ra *ra, const struct pl_tex *pltex,
                    struct ra_tex *out_tex);

--- a/video/out/vulkan/context_xlib.c
+++ b/video/out/vulkan/context_xlib.c
@@ -66,6 +66,8 @@ static bool xlib_init(struct ra_ctx *ctx)
     if (!ra_vk_ctx_init(ctx, vk, VK_PRESENT_MODE_FIFO_KHR))
         goto error;
 
+    ra_add_native_resource(ctx->ra, "x11", ctx->vo->x11->display);
+
     return true;
 
 error:


### PR DESCRIPTION
This change is a first pass at vulkan interop for vaapi. I took the
existing hwdec_vaegl and replaced all the EGL logic with equivalent
Vulkan logic. Whether we end up with a separate file or separate
logic in one file (like with hwdec_cuda), I will need to adjust it
relative to what is in this change. So it's very much WIP.

The basic logic is very close to what is done for EGL except that
I've wrapped most of the fiddly bits in libplacebo so there is less
to see here. I also threw out the support for the older libva to
make things easier to read but it's still possible to support the
old API if desired.

The only really big item of note is that this is still using split
planes rather than attempting to use a multiplane surface. This
is because libplacebo doesn't support multiplane textures today.

Note that the egl interop code also uses split planes so that's not
new behaviour.

For completeness, I'll note that the libplacebo logic is not using
VK_EXT_image_drm_format_modifier yet because it's not widely
available and so format negotiation is not done properly, and we're
lucky that things work out.